### PR TITLE
allow IPv6

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -155,7 +155,7 @@ PrivateKey = $CLIENT_PRIVKEY
 Address = $CLIENT_ADDRESS/$PRIVATE_SUBNET_MASK
 [Peer]
 PublicKey = $SERVER_PUBKEY
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 0.0.0.0/0, ::/0 
 Endpoint = $SERVER_ENDPOINT
 PersistentKeepalive = 25" > $HOME/$CLIENT_NAME-wg0.conf
 


### PR DESCRIPTION
Wildcard IPv6 addresses, otherwise your IPv6 address from ISP will be visible and not VPNs remote.


