### PR TITLE
added missing linux headers package

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -92,13 +92,13 @@ if [ ! -f "$WG_CONFIG" ]; then
 	apt-get install software-properties-common -y
 	add-apt-repository ppa:wireguard/wireguard -y
 	apt update
-	apt install wireguard qrencode iptables-persistent -y
+	apt install linux-headers-$(uname -r) wireguard qrencode iptables-persistent -y
     elif [ "$DISTRO" == "Debian" ]; then
         echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
         printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
 		apt-get install software-properties-common -y
 		apt update
-		apt install wireguard qrencode iptables-persistent -y
+		apt install linux-headers-$(uname -r) wireguard qrencode iptables-persistent -y
     elif [ "$DISTRO" == "CentOS" ]; then
         curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
         yum install epel-release -y


### PR DESCRIPTION
To make wireguard work, there has to be linux headers present.

````
# ip link delete dev wg0
Cannot find device "wg0"

# modprobe wireguard 
modprobe: FATAL: Module wireguard not found in directory /lib/modules/4.9.0-9-amd64

#sudo apt install linux-headers-$(uname -r)

# modprobe wireguard 
success!! 

# ifconfig wg0
wg0: flags=209<UP,POINTOPOINT,RUNNING,NOARP>  mtu 1420
        inet 10.9.0.1  netmask 255.255.255.0  destination 10.9.0.1
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 1  (UNSPEC)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

````