### PR TITLE
added missing package in client setup - resolvconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The script can be configured by setting the following environment variables:
 
 Install WireGuard and reboot your computer:
 
-    sudo add-apt-repository ppa:wireguard/wireguard -y && sudo apt update && sudo apt install wireguard -y
+    sudo add-apt-repository ppa:wireguard/wireguard -y && sudo apt update && sudo apt install wireguard resolvconf -y
     sudo reboot
 
 Copy the file `/root/client-wg0.conf` from a remote server to your local PC path `/etc/wireguard/wg0.conf` and run 


### PR DESCRIPTION
resolvconf package is required for setting wg client systemd unit in ubuntu 

see the systemd error below
```
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link add wg0 type wireguard
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] wg setconf wg0 /dev/fd/63
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip -4 address add 10.9.0.3/24 dev wg0
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link set mtu 1420 up dev wg0
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] resolvconf -a wg0 -m 0 -x
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: /usr/bin/wg-quick: line 31: resolvconf: command not found
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link delete dev wg0
Oct 17 12:11:39 Asus-VivoBook systemd[1]: wg-quick@wg0.service: Main process exited, code=exited, status=127/n/a
Oct 17 12:11:39 Asus-VivoBook systemd[1]: wg-quick@wg0.service: Failed with result 'exit-code'.
Oct 17 12:11:39 Asus-VivoBook systemd[1]: Failed to start WireGuard via wg-quick(8) for wg0.
```